### PR TITLE
this is a suggestion for using the plugin everywhere for consistency and less boiler code

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "babel-loader": "^8.1.0",
     "html-webpack-plugin": "^4.2.0",
     "rimraf": "^3.0.2",
+    "storybook-webpack-federation-plugin": "^1.1.0",
     "webpack": "git://github.com/webpack/webpack.git#dev-1",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",

--- a/packages/app/src/App.jsx
+++ b/packages/app/src/App.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react'
 
 import { Content } from './Content'

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin')
+const { StorybookWebpackFederationPlugin } = require('storybook-webpack-federation-plugin')
 const merge = require('webpack-merge')
 
 const { webpackConfig } = require('@webpack5-playground/common')
@@ -19,18 +19,13 @@ module.exports = webpackConfig(base =>
       publicPath: 'http://localhost:3000/'
     },
     plugins: [
-      new ModuleFederationPlugin({
-        name: 'app',
-        library: { type: 'var', name: 'app' },
-        filename: 'remoteEntry.js',
+      new StorybookWebpackFederationPlugin({
         // Load federated modules from other remote entrypoints (see public/index.html)
-        remotes: {
-          header: 'header',
-          footer: 'footer',
-          ds: 'ds'
-        },
+        remotes: ["ds", "header", "footer"],
         shared: ['react', 'react-dom', '@chakra-ui/core', '@emotion/core', '@emotion/styled', 'emotion-theming']
-      }),
+
+        }
+      ),
       new HtmlWebpackPlugin({
         template: './public/index.html'
       })

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "^8.1.0",
     "html-webpack-plugin": "^4.2.0",
     "rimraf": "^3.0.2",
+    "storybook-webpack-federation-plugin": "^1.1.0",
     "webpack": "git://github.com/webpack/webpack.git#dev-1",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",

--- a/packages/footer/webpack.config.js
+++ b/packages/footer/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin')
+const { StorybookWebpackFederationPlugin } = require('storybook-webpack-federation-plugin')
 const merge = require('webpack-merge')
 
 const { webpackConfig } = require('@webpack5-playground/common')
@@ -19,19 +19,16 @@ module.exports = webpackConfig(base =>
       publicPath: 'http://localhost:3002/'
     },
     plugins: [
-      new ModuleFederationPlugin({
-        name: 'footer',
-        library: { type: 'var', name: 'footer' },
-        filename: 'remoteEntry.js',
-        // Exposes the Header as consumable module. Effectively, a microfrontend
-        exposes: {
-          Footer: './src/expose/Footer'
-        },
-        remotes: {
-          ds: 'ds'
-        },
-        shared: ['react', 'react-dom']
-      }),
+      new StorybookWebpackFederationPlugin({
+          name: 'footer',
+          remotes: ["ds"],
+          // Exposes the Footer as consumable module. Effectively, a microfrontend
+          files: {
+            paths: ['./src/expose/Footer.jsx'],
+            removePrefix: './src/expose/'
+          },
+        }
+      ),
       new HtmlWebpackPlugin({
         template: './public/index.html',
         chunks: ['main']

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -18,6 +18,7 @@
     "babel-loader": "^8.1.0",
     "html-webpack-plugin": "^4.2.0",
     "rimraf": "^3.0.2",
+    "storybook-webpack-federation-plugin": "^1.1.0",
     "webpack": "git://github.com/webpack/webpack.git#dev-1",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",

--- a/packages/header/webpack.config.js
+++ b/packages/header/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin')
+const { StorybookWebpackFederationPlugin } = require('storybook-webpack-federation-plugin')
 const merge = require('webpack-merge')
 
 const { webpackConfig } = require('@webpack5-playground/common')
@@ -19,19 +19,16 @@ module.exports = webpackConfig(base =>
       publicPath: 'http://localhost:3001/'
     },
     plugins: [
-      new ModuleFederationPlugin({
-        name: 'header',
-        library: { type: 'var', name: 'header' },
-        filename: 'remoteEntry.js',
-        // Exposes the Header as consumable module. Effectively, a microfrontend
-        exposes: {
-          Header: './src/expose/Header'
-        },
-        remotes: {
-          ds: 'ds'
-        },
-        shared: ['react', 'react-dom']
-      }),
+      new StorybookWebpackFederationPlugin({
+          name: 'header',
+          remotes: ["ds"],
+          // Exposes the Header as consumable module. Effectively, a microfrontend
+          files: {
+            paths: ['./src/expose/Header.jsx'],
+            removePrefix: './src/expose/'
+          },
+        }
+      ),
       new HtmlWebpackPlugin({
         template: './public/index.html',
         chunks: ['main']


### PR DESCRIPTION
The differences are not as stark when you only expose a single file here and there, but it still much cleaner, I think :-)
Was there a reason you haven't done this yourself right away this way? 